### PR TITLE
Fast UDAF

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ developers := List(
 )
 
 libraryDependencies ++= Seq(
-  "org.isarnproject" % "isarn-sketches-java" % "0.2.1",
+  "org.isarnproject" % "isarn-sketches-java" % "0.2.2-LOCAL",
   "org.apache.spark" %% "spark-core" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-mllib" % sparkVersion % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ initialCommands in console := """
   |import org.apache.spark.SparkContext._
   |import org.apache.spark.rdd.RDD
   |import org.apache.spark.ml.linalg.Vectors
-  |import org.isarnproject.sketches.TDigest
+  |import org.isarnproject.sketches.java.TDigest
   |import org.isarnproject.sketches.udaf._
   |import org.apache.spark.isarnproject.sketches.udt._
   |val initialConf = new SparkConf().setAppName("repl").set("spark.serializer", "org.apache.spark.serializer.KryoSerializer").set("spark.kryoserializer.buffer", "16mb")

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // xsbt clean unidoc previewSite
 // xsbt clean unidoc ghpagesPushSite
-// xsbt -Dsbt.global.base=/home/eje/.sbt/sonatype +publish
+// xsbt +publish
 // make sure sparkVersion and pythonVersion are set as you want them prior to +publish
 
 import scala.sys.process._
@@ -9,9 +9,9 @@ name := "isarn-sketches-spark"
 
 organization := "org.isarnproject"
 
-val packageVersion = "0.3.1"
+val packageVersion = "0.4.0-SNAPSHOT"
 
-val sparkVersion = "2.2.2"
+val sparkVersion = "2.4.0"
 
 val pythonVersion = "2.7"
 
@@ -28,6 +28,12 @@ scalaVersion := "2.11.12"
 crossScalaVersions := Seq("2.11.12") // scala 2.12 when spark supports it
 
 pomIncludeRepository := { _ => false }
+
+//isSnapshot := true
+
+//publishConfiguration := publishConfiguration.value.withOverwrite(true)
+
+//publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true)
 
 publishMavenStyle := true
 
@@ -60,7 +66,7 @@ developers := List(
 )
 
 libraryDependencies ++= Seq(
-  "org.isarnproject" %% "isarn-sketches" % "0.1.2",
+  "org.isarnproject" % "isarn-sketches-java" % "0.2.1",
   "org.apache.spark" %% "spark-core" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-mllib" % sparkVersion % Provided,

--- a/src/main/scala/org/isarnproject/sketches/udaf/package.scala
+++ b/src/main/scala/org/isarnproject/sketches/udaf/package.scala
@@ -18,6 +18,8 @@ import scala.language.implicitConversions
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.catalyst.util._
 
+import org.isarnproject.sketches.java.TDigest
+
 import org.apache.spark.isarnproject.sketches.udt._
 
 /** package-wide methods, implicits and definitions for sketching UDAFs */
@@ -40,7 +42,7 @@ package object udaf {
   def tdigestUDAF[N](implicit
     num: Numeric[N],
     dataType: TDigestUDAFDataType[N])
-  = TDigestUDAF(TDigest.deltaDefault, 0)
+  = TDigestUDAF(TDigest.COMPRESSION_DEFAULT, 0)
 
   /**
    * Obtain a UDAF for sketching a numeric array-data Dataset column, using a t-digest for
@@ -61,7 +63,7 @@ package object udaf {
   def tdigestArrayUDAF[N](implicit
     num: Numeric[N],
     dataType: TDigestUDAFDataType[N])
-  = TDigestArrayUDAF(TDigest.deltaDefault, 0)
+  = TDigestArrayUDAF(TDigest.COMPRESSION_DEFAULT, 0)
 
   /**
    * Obtain a UDAF for sketching an ML Vector Dataset column, using a t-digest for
@@ -78,7 +80,7 @@ package object udaf {
    * val tdArray = agg.getAs[TDigestArraySQL](0).tdigests
    * }}}
    */
-  def tdigestMLVecUDAF = TDigestMLVecUDAF(TDigest.deltaDefault, 0)
+  def tdigestMLVecUDAF = TDigestMLVecUDAF(TDigest.COMPRESSION_DEFAULT, 0)
 
   /**
    * Obtain a UDAF for sketching an MLLib Vector Dataset column, using a t-digest for
@@ -95,7 +97,7 @@ package object udaf {
    * val tdArray = agg.getAs[TDigestArraySQL](0).tdigests
    * }}}
    */
-  def tdigestMLLibVecUDAF = TDigestMLLibVecUDAF(TDigest.deltaDefault, 0)
+  def tdigestMLLibVecUDAF = TDigestMLLibVecUDAF(TDigest.COMPRESSION_DEFAULT, 0)
 
   /**
    * Obtain a UDAF for aggregating (reducing) a column (or grouping) of t-digests
@@ -125,7 +127,7 @@ package object udaf {
    * +--------------------+
    * }}}
    */
-  def tdigestReduceUDAF = TDigestReduceUDAF(TDigest.deltaDefault, 0)
+  def tdigestReduceUDAF = TDigestReduceUDAF(TDigest.COMPRESSION_DEFAULT, 0)
 
   /**
    * Obtain a UDAF for aggregating (reducing) a column of t-digest vectors
@@ -155,7 +157,7 @@ package object udaf {
    * +---------------------+
    * }}}
    */
-  def tdigestArrayReduceUDAF = TDigestArrayReduceUDAF(TDigest.deltaDefault, 0)
+  def tdigestArrayReduceUDAF = TDigestArrayReduceUDAF(TDigest.COMPRESSION_DEFAULT, 0)
 
   /** implicitly unpack a TDigestSQL to extract its TDigest payload */
   implicit def implicitTDigestSQLToTDigest(tdsql: TDigestSQL): TDigest = tdsql.tdigest


### PR DESCRIPTION
Overall goal is to migrate from original scala immutable TDigest to new faster java mutable TDigest.

- [x] move to java TDigest
- [ ] get rid of TDigestSQL wrapper (maybe TDigestArraySQL wrapper if possible)
- [ ] update pyspark bindings