### PR TITLE
fix: correct python TDigestUDT scala class path

### DIFF
--- a/python/isarnproject/sketches/spark/tdigest.py
+++ b/python/isarnproject/sketches/spark/tdigest.py
@@ -197,7 +197,7 @@ class TDigestUDT(UserDefinedType):
 
     @classmethod
     def scalaUDT(cls):
-        return "org.apache.spark.isarnproject.sketches.udtdev.TDigestUDT"
+        return "org.apache.spark.isarnproject.sketches.tdigest.udt.TDigestUDT"
 
     def simpleString(self):
         return "tdigest"


### PR DESCRIPTION
Hi. I tried to use `TDigestUDT` in Pyspark and got a class not found error. So I changed the Scala classpath and it worked. Please consider merging this to fix the issue.